### PR TITLE
Fix transformation of C names that have capitalized letters

### DIFF
--- a/cl_bindgen/__main__.py
+++ b/cl_bindgen/__main__.py
@@ -1,8 +1,5 @@
 import sys
 
-from cl_bindgen.processfile import ProcessOptions
-from cl_bindgen.macro_util import macro_matches_file_path
-import cl_bindgen.mangler as mangler
 import cl_bindgen.util as util
 
 def main():

--- a/cl_bindgen/mangler.py
+++ b/cl_bindgen/mangler.py
@@ -11,6 +11,7 @@ Each mangler class follows the following interface:
 """
 
 import re
+import io
 
 class PrefixMangler:
     """ Mangler to replace the prefix of a string wtih a given string."""
@@ -60,14 +61,15 @@ class ConstantMangler:
         if ':' in string:
             # Remove any possible package prefix and save it:
             (pkg_prefix, colon, symb) = string.rpartition(':')
-            return pkg_prefix + ':+' + symb + '+'
+            result = pkg_prefix + ':+' + symb + '+'
         else:
-            return "+" + string + "+"
+            result = "+" + string + "+"
+        return result.lower()
 
 class UnderscoreMangler:
     """ Converts underscores to dashes"""
 
-    def __init(self):
+    def __init__(self):
         pass
 
     def can_mangle(self, string):
@@ -92,3 +94,26 @@ class RegexSubMangler:
 
     def mangle(self, string):
         return re.sub(self.regex, self.replace, string)
+
+class CamelCaseConverter:
+    """" Convert camelCase and TitleCase to common lisp case.
+
+    Doesn't seperate consecutive capitilzations into spaces, i.e.
+    IString gets converted into istring, ThingDNE gets converted
+    to thing-dne
+    """
+    def __init__(self):
+        pass
+
+    def can_mangle(self, string):
+        return len(string) > 0
+
+    def mangle(self, string):
+        builder = io.StringIO()
+        builder.write(string[0].lower())
+        for i in range(1, len(string)):
+            cur_char = string[i]
+            if cur_char.isupper() and not string[i-1].isupper():
+                builder.write('-')
+            builder.write(cur_char.lower())
+        return builder.getvalue()

--- a/cl_bindgen/util.py
+++ b/cl_bindgen/util.py
@@ -17,16 +17,17 @@ def build_default_options():
     u_mangler =  mangler.UnderscoreMangler()
     k_mangler =   mangler.KeywordMangler()
     const_mangler = mangler.ConstantMangler()
+    case_mangler = mangler.CamelCaseConverter()
 
     # manglers are applied in the order that they are given in these lists:
     # enum manglers transform enum fields, e.g. FOO, BAR in enum { FOO, BAR }
-    enum_manglers = [k_mangler, u_mangler]
+    enum_manglers = [case_mangler, k_mangler, u_mangler]
     # type mangers are applied to struct names, function names, and type names
-    type_manglers = [u_mangler]
+    type_manglers = [case_mangler, u_mangler]
     # name manglers are applied to parameters and variables
-    name_manglers = [u_mangler]
+    name_manglers = [case_mangler, u_mangler]
     # typedef manglers are applied to typedefs
-    typedef_manglers = [u_mangler]
+    typedef_manglers = [case_mangler, u_mangler]
     constant_manglers = [u_mangler, const_mangler]
 
     return processfile.ProcessOptions(typedef_manglers=typedef_manglers,

--- a/test/inputs/capitalization.h
+++ b/test/inputs/capitalization.h
@@ -1,0 +1,17 @@
+
+struct Foo {
+  int aBear;
+  int B;
+};
+
+int camelCaseFunctionName(int Test);
+
+int TitleCaseFunction(int TestFoo);
+
+int stringDNE();
+
+void IString();
+
+int snake_case_function(double weird_name);
+
+int SDL_testThing();

--- a/test/outputs/capitalization.lisp
+++ b/test/outputs/capitalization.lisp
@@ -1,0 +1,20 @@
+;; next section imported from file inputs/capitalization.h
+
+(cffi:defcstruct foo
+  (a-bear :int)
+  (b :int))
+
+(cffi:defcfun ("camelCaseFunctionName" camel-case-function-name) :int
+  (test :int))
+
+(cffi:defcfun ("TitleCaseFunction" title-case-function) :int
+  (test-foo :int))
+
+(cffi:defcfun ("stringDNE" string-dne) :int)
+
+(cffi:defcfun ("IString" istring) :void)
+
+(cffi:defcfun ("snake_case_function" snake-case-function) :int
+  (weird-name :double))
+
+(cffi:defcfun ("SDL_testThing" sdl-test-thing) :int)

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -33,7 +33,8 @@ tests = [
     ('inputs/typedef.h', 'outputs/typedef.lisp', {}),
     ('inputs/constant_array_in_struct.h', 'outputs/constant-array-in-struct.lisp', {}),
     ('inputs/standard_types.h', 'outputs/standard_types.lisp', {}),
-    ('inputs/forward_declaration.h', 'outputs/forward_declaration.lisp', {})
+    ('inputs/forward_declaration.h', 'outputs/forward_declaration.lisp', {}),
+    ('inputs/capitalization.h', 'outputs/capitalization.lisp', {})
 ]
 
 def test_file_generation():


### PR DESCRIPTION
Transform camelCase and TitleCase names to lisp-case, and keep
capitalization of c names when outputting them.

Should fix #11.