### PR TITLE
Fix nested anonymous records

### DIFF
--- a/cl_bindgen/processfile.py
+++ b/cl_bindgen/processfile.py
@@ -35,6 +35,18 @@ else:
     def _output_comment(cursor, output, before='', after=''):
         pass
 
+if hasattr(clang.Cursor, 'is_anonymous_record_decl'):
+    # This function was added in the llvm-project commit fbcf3cb7fe95d9d420b643ce379f7ee2106a6efc
+    # Which will be released in version 20? It's a simple definition though,
+    # so you can copy it into your cindex.py file and it should work.
+    def _is_anonymous_record_decl(cursor):
+        return cursor.is_anonymous_record_decl()
+else:
+    def _is_anonymous_record_decl(cursor):
+        # This won't work on some versions of libclang (particularlly libclang 17),
+        # as this spelling isn't empty, and is instead something like "(anonymous at ...)"
+        return cursor.spelling == ''
+
 class ParserException(Exception):
 
     def __init__(self, filepath, diagnostics):
@@ -283,7 +295,7 @@ def _process_record(name, actual_type, cursor, output, options):
     anon_count = 0
     for field in this_type.get_fields():
         field_name = _mangle_string(field.spelling.lower(), options.name_manglers)
-        if field_name == '':
+        if _is_anonymous_record_decl(field):
             field_name = 'anon-' + str(anon_count)
             anon_count = anon_count + 1
         if field.is_anonymous():


### PR DESCRIPTION
Commit
https://github.com/llvm/llvm-project/commit/19e984ef8f49bc3ccced15621989fa9703b2cd5b in the LLMV project changed the spellling of anonymous records, which broke the implementation. Use the methodology that you are supposed to use instead, which was added to the python bindings since this feature was originally implemented.
+ The function this uses, Cursor.is_anonymous_record_decl, hasn't made it to an clang release yet, but it is easy to add to your local copy. See the comment for where to find that.